### PR TITLE
Implemented view for all articles for a specified topic

### DIFF
--- a/api.js
+++ b/api.js
@@ -10,8 +10,9 @@ const getTopics = () => {
     })
 }
 
-const getAllArticles = () => {
-    return api.get("/articles").then(({data}) => {
+const getAllArticles = (topic) => {
+    const url = topic ? `/articles?topic=${topic}` : "/articles";
+    return api.get(url).then(({data}) => {
         return data.articles;
     })
 }

--- a/src/App.css
+++ b/src/App.css
@@ -63,7 +63,7 @@ h1{
 .bars {
   width: 100%;
   height: 4px;
-  background-color: rgb(176, 92, 255);
+  background-color: #007bff;
   border-radius: 4px;
 }
 
@@ -172,8 +172,9 @@ h1{
   height: 100vh;
   background: #28292c;
   transition: transform 0.3s ease-in-out;
-  padding-top: 15vh;
+  padding-top: 100px;
   padding-left: 2%;
+  z-index: 2;
 }
 
 .sidebar.closed {
@@ -182,6 +183,36 @@ h1{
 
 .sidebar.open {
   transform: translateX(0);
+}
+
+.sidebar button {
+  width: 70%;
+  padding: 10px;
+  margin: 10px 0;
+  background-color: #007bff;
+  color: white;
+  font-size: 16px;
+  border: none;
+  border-radius: 5px;
+  text-align: center;
+  cursor: pointer;
+  transition: background-color 0.3s ease, transform 0.2s ease;
+}
+
+.sidebar button:hover {
+  background-color: #0056b3;
+  transform: scale(1.05);
+}
+
+@media (max-width: 768px) {
+  .sidebar {
+    width: 200px;
+    padding: 150px 15px;
+  }
+
+  .sidebar button {
+    font-size: 14px;
+  }
 }
 
 .wheel-and-hamster {

--- a/src/components/ArticleList.jsx
+++ b/src/components/ArticleList.jsx
@@ -2,14 +2,19 @@ import { getAllArticles} from "../../api"
 import useApiRequest from "../hooks/useApiRequest"
 import ArticleCard from "./ArticleCard";
 import Loading from "./Loading";
+import { useSearchParams } from "react-router";
 
 export default function ArticleList() {
-    const {data: articles, isLoading, error} = useApiRequest(getAllArticles);
+    const [searchParams] = useSearchParams();
+    const topic = searchParams.get("topic");
+
+    const {data: articles, isLoading, error} = useApiRequest(getAllArticles, [topic]);
 
     return (
         <section id="article-list">
             {isLoading && <Loading/>}
             {error && <p>{error.msg}</p>}
+            {articles?.length === 0 && !isLoading && <p>No articles found for this topic.</p>}
             <ul>
                 {articles.map((article) => (
                     <ArticleCard key={article.article_id} article={article}/>

--- a/src/components/ArticleListView.jsx
+++ b/src/components/ArticleListView.jsx
@@ -1,9 +1,13 @@
 import ArticleList from "./ArticleList"
+import { useSearchParams } from "react-router"
 
 export default function ArticleListView() {
+    const [searchParams] = useSearchParams();
+    const topic = searchParams.get("topic");
+
     return(
         <main className="content">
-            <h2>Topic title</h2>
+            <h2>{topic ? `Articles about ${topic}` : "All Articles"}</h2>
             <ArticleList/>
         </main>
     )

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,19 +1,26 @@
 import SidebarButton from "./SidebarButton"
-import { useState, useEffect } from "react";
 import { getTopics } from "../../api";
 import { useSidebar } from "../Contexts/SidebarContext";
 import useApiRequest from "../hooks/useApiRequest"
 import Loading from "./Loading";
+import { useNavigate } from "react-router";
 
 export default function Sidebar() {
     const {isSidebarOpen} = useSidebar();
     const {data: topics, isLoading, error} = useApiRequest(getTopics);
 
+    const navigate = useNavigate();
+    const handleClick = () => {
+        navigate("/");
+    }
+
     return (
         <aside id="sidebar" className={`sidebar ${isSidebarOpen ? "open" : "closed"}`}>
             {isLoading && <Loading/>}
             {error && <p>{error.msg}</p>}
+            <h3>Topics:</h3>
             <ul>
+                <li><button onClick={handleClick}>All articles</button></li>
                 {topics.map((topic) => (
                     <SidebarButton key={topic.slug} topic={topic} />
                 ))}

--- a/src/components/SidebarButton.jsx
+++ b/src/components/SidebarButton.jsx
@@ -1,5 +1,13 @@
+import { useNavigate } from "react-router";
+
 export default function SidebarButton({topic}) {
+    const navigate = useNavigate();
+
+    const handleClick = () => {
+        navigate(`/?topic=${topic.slug}`);
+    }
+
     return (
-        <li><button>{topic.slug}</button></li>
+        <li><button onClick={handleClick}>{topic.slug}</button></li>
     )
 }

--- a/src/hooks/useApiRequest.jsx
+++ b/src/hooks/useApiRequest.jsx
@@ -19,7 +19,7 @@ const useApiRequest = (apiFunction, ...args) => {
             .finally(() => {
                 setIsLoading(false);
             });
-    }, [...args]);
+    }, [JSON.stringify(args)]);
 
     return {data, isLoading, error};
 }


### PR DESCRIPTION
This commit includes:
- The implementation of the query to narrow down the all article view to only display articles matching the queried topic.
- The implementation of the sidebar buttons to navigate the user to their respective topic query views.
- The addition of an all articles button in case users are unaware that the h1 navigates to that view.
- Styling for the Sidebar buttons and minor adjustment to sidebar styling to ensure it renders above article cards but below header.