### PR TITLE
Adjusted Header appearance on mobile devices

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -125,20 +125,23 @@ h1{
   position: relative;
   width: 100px;
   height: 50px;
-  --light: #dae3f5;
-  --dark: #060e1f;
+  --light: #ffffff;
+  --dark: #081329;
   --link: rgb(27, 129, 112);
   --link-hover: rgb(24, 94, 82);
+
+  /* --light: #dae3f5;
+  --dark: #060e1f; */
 }
 
 .switch-label {
   position: absolute;
   width: 100%;
   height: 50px;
-  /* background-color: var(--dark); */
+  background-color: var(--dark);
   border-radius: 25px;
   cursor: pointer;
-  border: 3px solid #007bff;
+  border: 2px solid #007bff;
 }
 
 .checkbox {
@@ -185,18 +188,54 @@ h1{
 
 @media (max-width: 400px) {
   h1 {
-    font-size: 1.4rem;
+    font-size: 1.7rem;
     white-space: normal;
     text-align: center;
     width: 100%;
-    position: static;
-    transform: none;
-    margin-top: 10px;
   }
+  
+  header a {
+  text-decoration: none;
+  color: inherit;
+}
 
   header {
     flex-wrap: wrap;
     height: auto;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .toggle {
+    width: 35px;
+    height: 35px;
+    gap: 8px;
+  }
+
+  .bars {
+    height: 3.5px;
+    border-radius: 3.5px;
+  }
+
+  #toggle-theme {
+    width: 85px;
+    height: 40px;
+  }
+
+  .switch-label {
+    height: 40px;
+    border-radius: 20px;
+  }
+
+  .slider::before {
+    top: 7px;
+    left: 7px;
+    width: 22px;
+    height: 22px;
+  }
+
+  .checkbox:checked ~ .slider::before {
+    transform: translateX(40px);
   }
 }
 


### PR DESCRIPTION
This commit includes:
- Colour changes to the toggle theme slider.
- Changes to the sizes of header elements on screens below 400px in width.
- Fixed centering of header elements on screens below 400px in width.
- Removed the underline displayed on the h1 hyperlink on screens below 400px in width.